### PR TITLE
Give shortcuts an optional alias field for better filter results

### DIFF
--- a/public/shortcuts.json
+++ b/public/shortcuts.json
@@ -1,6 +1,6 @@
 [{
   "name": "Copy",
-  "description": "Copys the selected code.",
+  "description": "Copies the selected code.",
   "binding": ["Ctrl", "C"],
   "benefit": 5
 }, {
@@ -59,30 +59,35 @@
   "name": "Rename variable",
   "description": "Rename selected (cursor position) variable. Also works for xml/html tags.",
   "vsCodeKey": "editor.action.rename",
+  "alias": "refactor",
   "binding": ["F2"],
   "benefit": 5
 }, {
   "name": "Goto file …",
   "description": "Opens VS Code prompt to search a file.",
   "vsCodeKey": "workbench.action.quickOpen",
+  "alias": "open prompt",
   "binding": ["Ctrl", "P"],
   "benefit": 5
 }, {
   "name": "Enter VS Code command …",
   "description": "Opens VS Code prompt to enter a command.",
   "vsCodeKey": "workbench.action.showCommands",
+  "alias": "run execute prompt",
   "binding": ["Ctrl", "Shift", "P"],
   "benefit": 5
 }, {
   "name": "Format document",
   "description": "Format the entire active file. Out-of-the-box support for JavaScript, TypeScript, JSON, HTML and CSS. Other languages work if matching formatters / language extensions are installed.",
   "vsCodeKey": "editor.action.formatDocument",
+  "alias": "indent, autoindent",
   "binding": ["Ctrl", "Shift", "I"],
   "benefit": 5
 }, {
   "name": "Format selection",
   "description": "Format the selected text. Out-of-the-box support for JavaScript, TypeScript, JSON, HTML and CSS. Other languages work if matching formatters / language extensions are installed.",
   "vsCodeKey": "editor.action.formatSelection",
+  "alias": "indent autoindent",
   "binding": ["Ctrl", "K", "Ctrl", "F"],
   "benefit": 5
 }, {
@@ -95,6 +100,7 @@
   "name": "Expand Selection",
   "description": "Expands the current selection using semantic knowledge.",
   "vsCodeKey": "editor.action.smartSelect.expand",
+  "alias": "grow",
   "binding": ["Shift", "Alt", "Right"],
   "benefit": 4
 }, {
@@ -119,6 +125,7 @@
   "name": "Open Keyboard Shortcuts",
   "description": "Show list of configured global key bindings",
   "vsCodeKey": "workbench.action.openGlobalKeybindings",
+  "alias": "binding",
   "binding": ["Ctrl", "K", "S"],
   "benefit": 4
 }]

--- a/src/models/Shortcut.ts
+++ b/src/models/Shortcut.ts
@@ -6,6 +6,7 @@ export type Shortcut = {
   name: string;
   description: string;
   binding: Binding;
+  alias?: string; // mainly for searching e.g. 'format' ≈ 'indent'
   vsCodeKey?: string;
   benefit?: 1 | 2 | 3 | 4 | 5;
 }

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -22,7 +22,8 @@ export const filteredShortcuts = derived([shortcuts, shortcutFilter], ([$shortcu
   }
   return $shortcuts.filter(shortcut =>
     shortcut.name.toLowerCase().includes($filter.toLowerCase()) ||
-    shortcut.vsCodeKey?.toLowerCase().includes($filter.toLowerCase())
+    shortcut.vsCodeKey?.toLowerCase().includes($filter.toLowerCase()) ||
+    shortcut.alias?.toLowerCase().includes($filter.toLowerCase())
   )
 })
 


### PR DESCRIPTION
… mainly for searching / filtering e.g. `format` ≈ `indent`.

Please review.